### PR TITLE
Fix Barncancerfonden Profile image

### DIFF
--- a/member-service/src/main/java/com/hedvig/memberservice/services/CashbackService.java
+++ b/member-service/src/main/java/com/hedvig/memberservice/services/CashbackService.java
@@ -37,7 +37,7 @@ public class CashbackService {
             false,
             true,
             "https://s3.eu-central-1.amazonaws.com/com-hedvig-web-content/barncancerfonden.png",
-            "https://www.barncancerfonden.se/contentassets/7a2c1f9232344929903730483e9257f5/jag-stodjer_bcf.png",
+            "https://s3.eu-central-1.amazonaws.com/com-hedvig-web-content/barncancerfonden-2.png",
             "",
             "När Hedvig har betalat årets alla skador går din andel av överskottet till att stödja kampen mot barncancer");
 


### PR DESCRIPTION
Currently we are directly linking to an asset hosted by BCF which 404s

This is bad. We should host it ourselves, which this fix accomplishes