### PR TITLE
deprecate v1 sign

### DIFF
--- a/member-service/src/main/java/com/hedvig/common/DeprecatedException.kt
+++ b/member-service/src/main/java/com/hedvig/common/DeprecatedException.kt
@@ -1,0 +1,3 @@
+package com.hedvig.common
+
+class DeprecatedException(message: String): RuntimeException(message)

--- a/member-service/src/main/java/com/hedvig/memberservice/services/BankIdService.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/services/BankIdService.kt
@@ -30,17 +30,6 @@ class BankIdService(
         return status
     }
 
-    @Throws(UnsupportedEncodingException::class)
-    fun sign(ssn: String, userMessage: String, memberId: Long?, endUserIp: String?): OrderResponse {
-        val status = bankIdApi.sign(ssn, endUserIp, userMessage)
-        trackSignToken(status.orderRef, memberId)
-        return status
-    }
-
-    private fun trackSignToken(referenceToken: String, memberId: Long?) {
-        trackReferenceToken(referenceToken, RequestType.SIGN, memberId)
-    }
-
     private fun trackAuthToken(referenceToken: String, memberId: Long?) {
         trackReferenceToken(referenceToken, RequestType.AUTH, memberId)
     }

--- a/member-service/src/main/java/com/hedvig/memberservice/web/AuthController.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/web/AuthController.kt
@@ -1,5 +1,6 @@
 package com.hedvig.memberservice.web
 
+import com.hedvig.common.DeprecatedException
 import com.hedvig.external.bankID.bankIdTypes.CollectResponse
 import com.hedvig.external.bankID.bankIdTypes.CollectStatus
 import com.hedvig.memberservice.aggregates.exceptions.BankIdReferenceUsedException
@@ -69,25 +70,9 @@ class AuthController @Autowired constructor(
 
     @PostMapping(path = ["sign"])
     @Throws(UnsupportedEncodingException::class)
+    @Deprecated("Use V2")
     fun sign(@RequestHeader(value = "x-forwarded-for", required = false) forwardedIp: String?, @RequestBody request: BankIdSignRequest): ResponseEntity<BankIdSignResponse> {
-        MDC.put("memberId", request.memberId)
-
-        val memberId = convertMemberId(request.memberId)
-
-        log.info(
-            "Sign request for ssn: ${request.ssn}", StructuredArguments.value("memberId", request.memberId))
-
-        val endUserIp = forwardedIp
-            .getEndUserIp("Header 'x-forwarded-for' was not included when calling AuthController sign! MemberId:$memberId")
-
-        val status = bankIdService.sign(request.ssn, request.userMessage, memberId, endUserIp)
-
-        val response = BankIdSignResponse(
-            autoStartToken = status.autoStartToken,
-            referenceToken = status.orderRef
-        )
-
-        return ResponseEntity.ok(response)
+        throw DeprecatedException("Use V2")
     }
 
     private fun convertMemberId(memberId: String): Long {


### PR DESCRIPTION
From my understanding, it's not used anymore: ![Screenshot from 2020-02-14 14-43-31](https://user-images.githubusercontent.com/2484732/74537432-5de1d480-4f3a-11ea-916e-0dc50aa4df8f.png)
