### PR TITLE
Add endpoint to edit editable info on a member

### DIFF
--- a/member-service/src/main/java/com/hedvig/memberservice/aggregates/MemberAggregate.java
+++ b/member-service/src/main/java/com/hedvig/memberservice/aggregates/MemberAggregate.java
@@ -5,28 +5,7 @@ import com.hedvig.common.UUIDGenerator;
 import com.hedvig.external.bisnodeBCI.BisnodeClient;
 import com.hedvig.external.bisnodeBCI.dto.Person;
 import com.hedvig.external.bisnodeBCI.dto.PersonSearchResult;
-import com.hedvig.memberservice.commands.AuthenticationAttemptCommand;
-import com.hedvig.memberservice.commands.BackfillPickedLocaleCommand;
-import com.hedvig.memberservice.commands.BankIdAuthenticationStatus;
-import com.hedvig.memberservice.commands.BankIdSignCommand;
-import com.hedvig.memberservice.commands.CreateMemberCommand;
-import com.hedvig.memberservice.commands.EditMemberInformationCommand;
-import com.hedvig.memberservice.commands.InactivateMemberCommand;
-import com.hedvig.memberservice.commands.InitializeAppleUserCommand;
-import com.hedvig.memberservice.commands.InsurnaceCancellationCommand;
-import com.hedvig.memberservice.commands.MemberCancelInsuranceCommand;
-import com.hedvig.memberservice.commands.MemberUpdateContactInformationCommand;
-import com.hedvig.memberservice.commands.NorwegianSignCommand;
-import com.hedvig.memberservice.commands.SelectNewCashbackCommand;
-import com.hedvig.memberservice.commands.SetFraudulentStatusCommand;
-import com.hedvig.memberservice.commands.SignMemberFromUnderwriterCommand;
-import com.hedvig.memberservice.commands.StartOnboardingWithSSNCommand;
-import com.hedvig.memberservice.commands.UpdateAcceptLanguageCommand;
-import com.hedvig.memberservice.commands.UpdateEmailCommand;
-import com.hedvig.memberservice.commands.UpdatePhoneNumberCommand;
-import com.hedvig.memberservice.commands.UpdatePickedLocaleCommand;
-import com.hedvig.memberservice.commands.UpdateSSNCommand;
-import com.hedvig.memberservice.commands.UpdateWebOnBoardingInfoCommand;
+import com.hedvig.memberservice.commands.*;
 import com.hedvig.memberservice.events.AcceptLanguageUpdatedEvent;
 import com.hedvig.memberservice.events.BirthDateUpdatedEvent;
 import com.hedvig.memberservice.events.EmailUpdatedEvent;
@@ -387,6 +366,23 @@ public class MemberAggregate {
     if (cmd.getMember().getPhoneNumber() != null
       && !Objects.equals(this.member.getPhoneNumber(), cmd.getMember().getPhoneNumber())) {
       apply(new PhoneNumberUpdatedEvent(this.id, cmd.getMember().getPhoneNumber()), MetaData.with("token", cmd.getToken()));
+    }
+  }
+
+  @CommandHandler
+  public void on(EditMemberInfoCommand cmd) {
+    String firstName = cmd.getFirstName() != null ? cmd.getFirstName() : member.getFirstName();
+    String lastName = cmd.getLastName() != null ? cmd.getLastName() : member.getLastName();
+    if (!firstName.equals(member.getFirstName()) || !lastName.equals(member.getLastName())) {
+      apply(new NameUpdatedEvent(this.id, firstName, lastName), MetaData.with("token", cmd.getToken()));
+    }
+
+    if (cmd.getEmail() != null && !cmd.getEmail().equals(member.getEmail())) {
+      apply(new EmailUpdatedEvent(this.id, cmd.getEmail()), MetaData.with("token", cmd.getToken()));
+    }
+
+    if (cmd.getPhoneNumber() != null && !cmd.getPhoneNumber().equals(member.getPhoneNumber())) {
+      apply(new PhoneNumberUpdatedEvent(this.id, cmd.getPhoneNumber()), MetaData.with("token", cmd.getToken()));
     }
   }
 

--- a/member-service/src/main/java/com/hedvig/memberservice/commands/EditMemberInfoCommand.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/commands/EditMemberInfoCommand.kt
@@ -1,0 +1,26 @@
+package com.hedvig.memberservice.commands
+
+import com.hedvig.memberservice.web.dto.EditMemberInfoRequest
+import org.axonframework.commandhandling.TargetAggregateIdentifier
+import java.lang.Long.parseLong
+
+class EditMemberInfoCommand(
+  @TargetAggregateIdentifier
+  val memberId: Long,
+  val firstName: String?,
+  val lastName: String?,
+  val email: String?,
+  val phoneNumber: String?,
+  val token: String
+) {
+  companion object {
+    fun from(request: EditMemberInfoRequest, token: String) = EditMemberInfoCommand(
+      memberId = parseLong(request.memberId),
+      firstName = request.firstName,
+      lastName = request.lastName,
+      email = request.email,
+      phoneNumber = request.phoneNumber,
+      token = token
+    )
+  }
+}

--- a/member-service/src/main/java/com/hedvig/memberservice/web/InternalMembersController.java
+++ b/member-service/src/main/java/com/hedvig/memberservice/web/InternalMembersController.java
@@ -4,11 +4,9 @@ import com.hedvig.memberservice.aggregates.PickedLocale;
 import com.hedvig.memberservice.commands.*;
 import com.hedvig.memberservice.query.MemberEntity;
 import com.hedvig.memberservice.query.MemberRepository;
-import com.hedvig.memberservice.services.SigningService;
 import com.hedvig.memberservice.services.member.MemberQueryService;
 import com.hedvig.memberservice.services.trace.TraceMemberService;
 import com.hedvig.memberservice.web.dto.*;
-import lombok.val;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +27,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping({"/i/member", "/_/member"})
@@ -156,13 +153,22 @@ public class InternalMembersController {
   public void editMember(
     @PathVariable("memberId") String memberId,
     @RequestBody InternalMember dto,
-    @RequestHeader("Authorization") String token) {
+    @RequestHeader("Authorization") String token
+  ) {
 
     Optional<MemberEntity> member = memberRepository.findById(Long.parseLong(memberId));
 
     if (member.isPresent() && !InternalMember.fromEntity(member.get()).equals(dto)) {
       commandBus.sendAndWait(new EditMemberInformationCommand(memberId, dto, token));
     }
+  }
+
+  @PostMapping("/edit/info")
+  public void editMemberInfo(
+    @RequestBody EditMemberInfoRequest request,
+    @RequestHeader("Authorization") String token
+  ) {
+    commandBus.sendAndWait(EditMemberInfoCommand.Companion.from(request, token));
   }
 
   @PostMapping(value = "/{memberId}/updateSSN")

--- a/member-service/src/main/java/com/hedvig/memberservice/web/dto/EditMemberInfoRequest.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/web/dto/EditMemberInfoRequest.kt
@@ -1,0 +1,9 @@
+package com.hedvig.memberservice.web.dto
+
+data class EditMemberInfoRequest(
+  val memberId: String,
+  val firstName: String?,
+  val lastName: String?,
+  val email: String?,
+  val phoneNumber: String?
+)


### PR DESCRIPTION
I'll remove the old one that sends a whole member when this is deployed and works.