### PR TITLE
Check if the member has signed when checking if a person has signed

### DIFF
--- a/member-service/src/main/java/com/hedvig/memberservice/query/MemberRepository.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/query/MemberRepository.kt
@@ -13,20 +13,24 @@ interface MemberRepository : JpaRepository<MemberEntity, Long> {
 
     fun findAllByIdIn(ids: List<Long>): List<MemberEntity>
 
-    @Query("""
+    @Query(
+        """
       FROM MemberEntity
       WHERE status != 'SIGNED' AND (ssn = :ssn OR email = :email) AND id != :memberId
-    """)
+    """
+    )
     fun findNonSignedBySsnOrEmailAndNotId(
         ssn: String,
         email: String,
         memberId: Long
     ): List<MemberEntity>
 
-    @Query("""
+    @Query(
+        """
         FROM MemberEntity
         WHERE (status = 'SIGNED' OR status='TERMINATED') AND (ssn = :ssn OR email = :email)
-    """)
+    """
+    )
     fun findSignedMembersBySsnOrEmail(
         ssn: String?,
         email: String
@@ -35,7 +39,8 @@ interface MemberRepository : JpaRepository<MemberEntity, Long> {
     @Query("select count(*) from MemberEntity m where m.status = 'SIGNED'")
     fun countSignedMembers(): Long?
 
-    @Query("""
+    @Query(
+        """
         SELECT m
         FROM MemberEntity m
         WHERE
@@ -50,13 +55,15 @@ interface MemberRepository : JpaRepository<MemberEntity, Long> {
                 OR LOWER(m.email) LIKE ('%' || LOWER(:query) || '%')
                 OR m.phoneNumber LIKE ('%' || :query || '%')
             )
-    """)
+    """
+    )
     fun searchSignedOrTerminated(
         @Param("query") query: String,
         p: Pageable
     ): Page<MemberEntity>
 
-    @Query("""
+    @Query(
+        """
         SELECT m
         FROM MemberEntity m
         WHERE
@@ -67,7 +74,8 @@ interface MemberRepository : JpaRepository<MemberEntity, Long> {
             OR m.ssn LIKE ('%' || :query || '%')
             OR LOWER(m.email) LIKE ('%' || LOWER(:query) || '%')
             OR m.phoneNumber LIKE ('%' || :query || '%')
-    """)
+    """
+    )
     fun searchAll(
         @Param("query") query: String,
         p: Pageable
@@ -75,11 +83,12 @@ interface MemberRepository : JpaRepository<MemberEntity, Long> {
 
     fun findByStatus(status: MemberStatus): List<MemberEntity>
 
-    fun findAllByStatusAndSsnNotIn(status:MemberStatus, ssns: List<String>): List<MemberEntity>
+    fun findAllByStatusAndSsnNotIn(status: MemberStatus, ssns: List<String>): List<MemberEntity>
 
-
-    @Query("""
+    @Query(
+        """
         SELECT m.id from MemberEntity m WHERE m.pickedLocale is null and (first_name is null or first_name != 'GDPR')
-    """)
+    """
+    )
     fun findIdsWithNoPickedLocale(pageable: Pageable): Page<Long>
 }

--- a/member-service/src/main/java/com/hedvig/personservice/persons/web/PersonController.kt
+++ b/member-service/src/main/java/com/hedvig/personservice/persons/web/PersonController.kt
@@ -1,13 +1,19 @@
 package com.hedvig.personservice.persons.web
 
-import com.hedvig.personservice.persons.web.dtos.HasPersonSignedBeforeRequest
 import com.hedvig.personservice.persons.PersonService
 import com.hedvig.personservice.persons.model.PersonFlags
+import com.hedvig.personservice.persons.web.dtos.HasSignedBeforeRequest
 import com.hedvig.personservice.persons.web.dtos.PersonDto
 import com.hedvig.personservice.persons.web.dtos.PersonStatusDto
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/_/person")
@@ -82,8 +88,8 @@ class PersonController @Autowired constructor(
     }
 
     @PostMapping("/has/signed")
-    fun hasSigned(@RequestBody request: HasPersonSignedBeforeRequest): ResponseEntity<Boolean> {
-        val hasSigned = personService.hasSigned(request.ssn, request.email)
+    fun hasSigned(@RequestBody request: HasSignedBeforeRequest): ResponseEntity<Boolean> {
+        val hasSigned = personService.hasSigned(request.memberId, request.ssn, request.email)
         return ResponseEntity.ok(hasSigned)
     }
 }

--- a/member-service/src/main/java/com/hedvig/personservice/persons/web/dtos/HasSignedBeforeRequest.kt
+++ b/member-service/src/main/java/com/hedvig/personservice/persons/web/dtos/HasSignedBeforeRequest.kt
@@ -1,6 +1,7 @@
 package com.hedvig.personservice.persons.web.dtos
 
-data class HasPersonSignedBeforeRequest(
+data class HasSignedBeforeRequest(
+    val memberId: String,
     val ssn: String?,
     val email: String
 )

--- a/member-service/src/main/java/com/hedvig/personservice/persons/web/dtos/PersonStatusDto.kt
+++ b/member-service/src/main/java/com/hedvig/personservice/persons/web/dtos/PersonStatusDto.kt
@@ -1,6 +1,5 @@
 package com.hedvig.personservice.persons.web.dtos
 
-import com.hedvig.personservice.persons.PersonService
 import com.hedvig.personservice.persons.model.Flag
 import com.hedvig.personservice.persons.model.Person
 


### PR DESCRIPTION
Why?
-  We have a bug where we update the customer.io attributes (first name, last name, email + send event) for members who onboard again on the same device but with new info

What?
- Check if the member has signed as well as the ssn and email

Risks?
- We have to deploy the consumers of this endpoint at the same time since the dto was extended with new non-nullable properties. I could do it by creating another endpoint etc. but I figured the risk is low enough to not bother with that.