### PR TITLE
add default cashback on simple sign

### DIFF
--- a/member-service/src/main/java/com/hedvig/memberservice/aggregates/MemberAggregate.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/aggregates/MemberAggregate.kt
@@ -359,6 +359,7 @@ class MemberAggregate() {
     fun handle(cmd: MemberSimpleSignedCommand) {
         val identification = cmd.nationalIdentification.identification
         val nationality = cmd.nationalIdentification.nationality
+        apply(NewCashbackSelectedEvent(id, cashbackService.getDefaultId(id).toString()))
         apply(MemberSimpleSignedEvent(cmd.id, identification, toMemberSimpleSignedEventNationality(nationality), cmd.referenceId))
         apply(SSNUpdatedEvent(id, identification, toSSNUpdatedEventNationality(nationality)))
     }

--- a/member-service/src/test/java/com/hedvig/memberservice/MemberAggregateTests.kt
+++ b/member-service/src/test/java/com/hedvig/memberservice/MemberAggregateTests.kt
@@ -406,6 +406,7 @@ class MemberAggregateTests {
         val personalNumber = "198902171234"
         val nationalIdentification = NationalIdentification(personalNumber, Nationality.SWEDEN)
         val refId = UUID.randomUUID()
+        every { cashbackService.getDefaultId(any()) } returns DEFAULT_CASHBACK
         fixture
             .given(
                 MemberCreatedEvent(memberId, MemberStatus.INITIATED, Instant.now())
@@ -413,6 +414,7 @@ class MemberAggregateTests {
             .`when`(MemberSimpleSignedCommand(memberId, nationalIdentification, refId))
             .expectSuccessfulHandlerExecution()
             .expectEvents(
+                NewCashbackSelectedEvent(memberId, DEFAULT_CASHBACK.toString()),
                 MemberSimpleSignedEvent(memberId, personalNumber, MemberSimpleSignedEvent.Nationality.SWEDEN, refId),
                 SSNUpdatedEvent(memberId, personalNumber, SSNUpdatedEvent.Nationality.SWEDEN)
             )


### PR DESCRIPTION
## What?
- No cashback was selected on "simple sign"

## Why?
- Always add default cashback on sign

## Optional checklist
- [x] Unit tests written
- [ ] Tested locally
- [ ] Codescouted
