### PR TITLE
Add the correct encoder and decoder for the feign client

### DIFF
--- a/member-service/src/main/java/com/hedvig/memberservice/services/trustpilot/TrustpilotConfig.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/services/trustpilot/TrustpilotConfig.kt
@@ -9,6 +9,7 @@ import feign.Feign
 import feign.codec.Decoder
 import feign.codec.Encoder
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.cloud.openfeign.FeignClientsConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/member-service/src/main/java/com/hedvig/memberservice/services/trustpilot/TrustpilotConfig.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/services/trustpilot/TrustpilotConfig.kt
@@ -4,33 +4,43 @@ import com.hedvig.integration.notificationService.NotificationService
 import com.hedvig.memberservice.query.MemberRepository
 import com.hedvig.memberservice.services.trustpilot.api.TrustpilotClient
 import com.hedvig.memberservice.services.trustpilot.api.TrustpilotOauth2Interceptor
+import feign.Contract
 import feign.Feign
+import feign.codec.Decoder
+import feign.codec.Encoder
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.cloud.openfeign.support.SpringMvcContract
+import org.springframework.cloud.openfeign.FeignClientsConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 import org.springframework.web.client.RestTemplate
 
 @Configuration
 @ConditionalOnProperty("trustpilot.customerio-review-links-enabled")
-class TrustpilotConfig {
+@Import(FeignClientsConfiguration::class)
+class TrustpilotConfig(
+    private val notificationService: NotificationService,
+    private val memberRepository: MemberRepository,
+    @Value("\${trustpilot.oauth.apikey}") private val apikey: String,
+    @Value("\${trustpilot.oauth.secret}") private val secret: String,
+    @Value("\${trustpilot.oauth.username}") private val username: String,
+    @Value("\${trustpilot.oauth.password}") private val password: String
+) {
 
     @Bean
     fun eventListener(
-        notificationService: NotificationService,
-        memberRepository: MemberRepository,
-        @Value("\${trustpilot.oauth.apikey}") apikey: String,
-        @Value("\${trustpilot.oauth.secret}") secret: String,
-        @Value("\${trustpilot.oauth.username}") username: String,
-        @Value("\${trustpilot.oauth.password}") password: String
+        encoder: Encoder,
+        decoder: Decoder,
+        contract: Contract
     ): CustomerIOTrustpilotEventListener {
         return CustomerIOTrustpilotEventListener(
             notificationService = notificationService,
             memberRepository =  memberRepository,
             trustpilotReviewService = TrustpilotReviewServiceImpl(
                 trustpilotClient = Feign.builder()
-                    .contract(SpringMvcContract()) // enables spring annotations like @PostMapping
+                    .encoder(encoder)
+                    .decoder(decoder)
+                    .contract(contract)
                     .requestInterceptor(TrustpilotOauth2Interceptor(RestTemplate(), apikey, secret, username, password))
                     .target(TrustpilotClient::class.java, "https://invitations-api.trustpilot.com/v1/private")
             )


### PR DESCRIPTION
# Jira Issue: -

## What?
The existing manually built feign client was missing the encoder/decoder that it should have been given from the spring environment. This will fix that.

## Why?
-

## Optional checklist
- [ ] Unit tests written
- [x] Tested locally
- [x] Codescouted
