### PR TITLE
simple sign attach token in static redirect to keep it around

### DIFF
--- a/member-service/src/main/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdService.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdService.kt
@@ -44,11 +44,12 @@ class ZignSecBankIdService(
         memberId: Long,
         personalNumber: String?,
         market: ZignSecAuthenticationMarket,
-        acceptLanguage: String?
+        acceptLanguage: String?,
+        authorization: String
     ): StartZignSecAuthenticationResult {
         if (market == ZignSecAuthenticationMarket.NORWAY && personalNumber == null) {
             return StartZignSecAuthenticationResult.StaticRedirect(
-                resolveNorwegianLoginUrl(memberId, acceptLanguage)
+                resolveNorwegianLoginUrl(memberId, acceptLanguage, authorization)
             )
         }
 
@@ -115,9 +116,13 @@ class ZignSecBankIdService(
 
     fun notifyContractsCreated(memberId: Long) = zignSecAuthentication.notifyContractsCreated(memberId)
 
-    private fun resolveNorwegianLoginUrl(memberId: Long, acceptLanguage: String?) = when (resolveLocaleFromMember(memberId, acceptLanguage)?.language) {
-        Locale("nb").language -> baseUrl + NORWEGIAN_BANK_ID_NORWEGIAN_LOGIN_PATH
-        else -> baseUrl + NORWEGIAN_BANK_ID_ENGLISH_LOGIN_PATH
+    private fun resolveNorwegianLoginUrl(
+        memberId: Long,
+        acceptLanguage: String?,
+        authorization: String
+    ) = when (resolveLocaleFromMember(memberId, acceptLanguage)?.language) {
+        Locale("nb").language -> "$baseUrl$NORWEGIAN_BANK_ID_NORWEGIAN_LOGIN_PATH?auth_token=$authorization"
+        else -> "$baseUrl$NORWEGIAN_BANK_ID_ENGLISH_LOGIN_PATH?auth_token=$authorization"
     }
 
     private fun resolveTwoLetterLanguageFromMember(memberId: Long, acceptLanguage: String?) = when (resolveLocaleFromMember(memberId, acceptLanguage)?.language) {

--- a/member-service/src/main/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdService.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdService.kt
@@ -121,8 +121,8 @@ class ZignSecBankIdService(
         acceptLanguage: String?,
         authorization: String
     ) = when (resolveLocaleFromMember(memberId, acceptLanguage)?.language) {
-        Locale("nb").language -> "$baseUrl$NORWEGIAN_BANK_ID_NORWEGIAN_LOGIN_PATH?auth_token=$authorization"
-        else -> "$baseUrl$NORWEGIAN_BANK_ID_ENGLISH_LOGIN_PATH?auth_token=$authorization"
+        Locale("nb").language -> "$baseUrl$NORWEGIAN_BANK_ID_NORWEGIAN_LOGIN_PATH#token=$authorization"
+        else -> "$baseUrl$NORWEGIAN_BANK_ID_ENGLISH_LOGIN_PATH#token=$authorization"
     }
 
     private fun resolveTwoLetterLanguageFromMember(memberId: Long, acceptLanguage: String?) = when (resolveLocaleFromMember(memberId, acceptLanguage)?.language) {

--- a/member-service/src/main/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdService.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdService.kt
@@ -17,6 +17,7 @@ import org.axonframework.commandhandling.gateway.CommandGateway
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import java.net.URLEncoder
 import java.util.*
 
 @Service
@@ -120,9 +121,12 @@ class ZignSecBankIdService(
         memberId: Long,
         acceptLanguage: String?,
         authorization: String
-    ) = when (resolveLocaleFromMember(memberId, acceptLanguage)?.language) {
-        Locale("nb").language -> "$baseUrl$NORWEGIAN_BANK_ID_NORWEGIAN_LOGIN_PATH#token=$authorization"
-        else -> "$baseUrl$NORWEGIAN_BANK_ID_ENGLISH_LOGIN_PATH#token=$authorization"
+    ): String {
+        val path = when (resolveLocaleFromMember(memberId, acceptLanguage)?.language) {
+            Locale("nb").language -> NORWEGIAN_BANK_ID_NORWEGIAN_LOGIN_PATH
+            else -> NORWEGIAN_BANK_ID_ENGLISH_LOGIN_PATH
+        }
+        return "$baseUrl$path#token=${URLEncoder.encode(authorization, Charsets.UTF_8)}"
     }
 
     private fun resolveTwoLetterLanguageFromMember(memberId: Long, acceptLanguage: String?) = when (resolveLocaleFromMember(memberId, acceptLanguage)?.language) {

--- a/member-service/src/main/java/com/hedvig/memberservice/web/AuthController.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/web/AuthController.kt
@@ -78,7 +78,8 @@ class AuthController @Autowired constructor(
                 BankIdAuthCountry.norway -> ZignSecAuthenticationMarket.NORWAY
                 BankIdAuthCountry.denmark -> ZignSecAuthenticationMarket.DENMARK
             },
-            acceptLanguage = acceptLanguage
+            acceptLanguage = acceptLanguage,
+            authorization = authorization.replace("Bearer ", "")
         )
 
         return when (result) {

--- a/member-service/src/main/java/com/hedvig/memberservice/web/AuthController.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/web/AuthController.kt
@@ -10,10 +10,12 @@ import com.hedvig.memberservice.web.dto.BankIdAuthCountry
 import com.hedvig.memberservice.web.dto.BankIdAuthRequest
 import com.hedvig.memberservice.web.dto.BankIdAuthResponse
 import com.hedvig.memberservice.web.dto.GenericBankIdAuthenticationRequest
+import com.hedvig.memberservice.web.dto.ZignSecStartDto
 import net.logstash.logback.argument.StructuredArguments
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.annotation.PathVariable
@@ -60,12 +62,34 @@ class AuthController @Autowired constructor(
     }
 
     @PostMapping(path = ["/{country}/bankid/auth"])
-    private fun auth(@RequestHeader("hedvig.token") memberId: Long, @RequestHeader(value = "Accept-Language", required = false) acceptLanguage: String?, @PathVariable("country") country: BankIdAuthCountry, @RequestBody request: GenericBankIdAuthenticationRequest): ResponseEntity<StartZignSecAuthenticationResult> {
-        return when (country) {
-            BankIdAuthCountry.norway ->
-                ResponseEntity.ok(zignSecBankIdService.authenticate(memberId, request, ZignSecAuthenticationMarket.NORWAY, acceptLanguage))
-            BankIdAuthCountry.denmark ->
-                ResponseEntity.ok(zignSecBankIdService.authenticate(memberId, request, ZignSecAuthenticationMarket.DENMARK, acceptLanguage))
+    private fun auth(
+        @RequestHeader("hedvig.token") memberId: Long,
+        @RequestHeader(value = "Accept-Language", required = false) acceptLanguage: String?,
+        @RequestHeader("Authorization") authorization: String,
+        @PathVariable("country") country: BankIdAuthCountry,
+        @RequestBody request: GenericBankIdAuthenticationRequest
+    ): ResponseEntity<ZignSecStartDto> {
+        MDC.put("memberId", memberId.toString())
+
+        val result = zignSecBankIdService.authenticate(
+            memberId = memberId,
+            personalNumber = request.personalNumber,
+            market = when (country) {
+                BankIdAuthCountry.norway -> ZignSecAuthenticationMarket.NORWAY
+                BankIdAuthCountry.denmark -> ZignSecAuthenticationMarket.DENMARK
+            },
+            acceptLanguage = acceptLanguage
+        )
+
+        return when (result) {
+            is StartZignSecAuthenticationResult.Success ->
+                ResponseEntity.ok(ZignSecStartDto(result.redirectUrl))
+            is StartZignSecAuthenticationResult.StaticRedirect ->
+                ResponseEntity.ok(ZignSecStartDto(result.redirectUrl))
+            is StartZignSecAuthenticationResult.Failed -> {
+                log.warn("ZignSec authentication start failed, codes = ${result.errors.map { it.code }}")
+                ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+            }
         }
     }
 

--- a/member-service/src/main/java/com/hedvig/memberservice/web/dto/ZignSecStartDto.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/web/dto/ZignSecStartDto.kt
@@ -1,0 +1,5 @@
+package com.hedvig.memberservice.web.dto
+
+data class ZignSecStartDto(
+    val redirectUrl: String
+)

--- a/member-service/src/test/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdServiceAuthenticateTest.kt
+++ b/member-service/src/test/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdServiceAuthenticateTest.kt
@@ -50,7 +50,8 @@ class ZignSecBankIdServiceAuthenticateTest {
             memberId,
             "ssn",
             ZignSecAuthenticationMarket.NORWAY,
-            null
+            null,
+            "token"
         )
 
         assertThat(response).isInstanceOf(StartZignSecAuthenticationResult.Success::class.java)
@@ -67,7 +68,8 @@ class ZignSecBankIdServiceAuthenticateTest {
             memberId,
             null,
             ZignSecAuthenticationMarket.DENMARK,
-            null
+            null,
+            "token"
         )
 
         assertThat(response).isInstanceOf(StartZignSecAuthenticationResult.Success::class.java)
@@ -82,7 +84,8 @@ class ZignSecBankIdServiceAuthenticateTest {
             memberId,
             null,
             ZignSecAuthenticationMarket.NORWAY,
-            null
+            null,
+            "token"
         )
 
         assertThat(response).isInstanceOf(StartZignSecAuthenticationResult.StaticRedirect::class.java)
@@ -97,7 +100,8 @@ class ZignSecBankIdServiceAuthenticateTest {
             memberId,
             null,
             ZignSecAuthenticationMarket.NORWAY,
-            "nb-NO"
+            "nb-NO",
+            "token"
         )
 
         assertThat(response).isInstanceOf(StartZignSecAuthenticationResult.StaticRedirect::class.java)
@@ -112,7 +116,8 @@ class ZignSecBankIdServiceAuthenticateTest {
             memberId,
             null,
             ZignSecAuthenticationMarket.NORWAY,
-            null
+            null,
+            "token"
         )
 
         assertThat(response).isInstanceOf(StartZignSecAuthenticationResult.StaticRedirect::class.java)
@@ -127,7 +132,8 @@ class ZignSecBankIdServiceAuthenticateTest {
             memberId,
             null,
             ZignSecAuthenticationMarket.NORWAY,
-            "en-NO"
+            "en-NO",
+            "token"
         )
 
         assertThat(response).isInstanceOf(StartZignSecAuthenticationResult.StaticRedirect::class.java)
@@ -142,7 +148,8 @@ class ZignSecBankIdServiceAuthenticateTest {
             memberId,
             null,
             ZignSecAuthenticationMarket.NORWAY,
-            null
+            null,
+            "token"
         )
 
         assertThat(response).isInstanceOf(StartZignSecAuthenticationResult.StaticRedirect::class.java)
@@ -157,7 +164,8 @@ class ZignSecBankIdServiceAuthenticateTest {
             memberId,
             null,
             ZignSecAuthenticationMarket.NORWAY,
-            null
+            null,
+            "token"
         )
 
         assertThat(response).isInstanceOf(StartZignSecAuthenticationResult.StaticRedirect::class.java)
@@ -170,7 +178,7 @@ class ZignSecBankIdServiceAuthenticateTest {
 
     companion object {
         private const val memberId = 1234L
-        private const val englishUrl = "https://www.dev.hedvigit.com/no-en/login"
-        private const val norwegianUrl = "https://www.dev.hedvigit.com/no/login"
+        private const val englishUrl = "https://www.dev.hedvigit.com/no-en/login?auth_token=token"
+        private const val norwegianUrl = "https://www.dev.hedvigit.com/no/login?auth_token=token"
     }
 }

--- a/member-service/src/test/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdServiceAuthenticateTest.kt
+++ b/member-service/src/test/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdServiceAuthenticateTest.kt
@@ -48,7 +48,7 @@ class ZignSecBankIdServiceAuthenticateTest {
 
         val response = sut.authenticate(
             memberId,
-            GenericBankIdAuthenticationRequest("ssn"),
+            "ssn",
             ZignSecAuthenticationMarket.NORWAY,
             null
         )
@@ -65,7 +65,7 @@ class ZignSecBankIdServiceAuthenticateTest {
 
         val response = sut.authenticate(
             memberId,
-            GenericBankIdAuthenticationRequest(null),
+            null,
             ZignSecAuthenticationMarket.DENMARK,
             null
         )
@@ -80,7 +80,7 @@ class ZignSecBankIdServiceAuthenticateTest {
 
         val response = sut.authenticate(
             memberId,
-            GenericBankIdAuthenticationRequest(null),
+            null,
             ZignSecAuthenticationMarket.NORWAY,
             null
         )
@@ -95,7 +95,7 @@ class ZignSecBankIdServiceAuthenticateTest {
 
         val response = sut.authenticate(
             memberId,
-            GenericBankIdAuthenticationRequest(null),
+            null,
             ZignSecAuthenticationMarket.NORWAY,
             "nb-NO"
         )
@@ -110,7 +110,7 @@ class ZignSecBankIdServiceAuthenticateTest {
 
         val response = sut.authenticate(
             memberId,
-            GenericBankIdAuthenticationRequest(null),
+            null,
             ZignSecAuthenticationMarket.NORWAY,
             null
         )
@@ -125,7 +125,7 @@ class ZignSecBankIdServiceAuthenticateTest {
 
         val response = sut.authenticate(
             memberId,
-            GenericBankIdAuthenticationRequest(null),
+            null,
             ZignSecAuthenticationMarket.NORWAY,
             "en-NO"
         )
@@ -140,7 +140,7 @@ class ZignSecBankIdServiceAuthenticateTest {
 
         val response = sut.authenticate(
             memberId,
-            GenericBankIdAuthenticationRequest(null),
+            null,
             ZignSecAuthenticationMarket.NORWAY,
             null
         )
@@ -155,7 +155,7 @@ class ZignSecBankIdServiceAuthenticateTest {
 
         val response = sut.authenticate(
             memberId,
-            GenericBankIdAuthenticationRequest(null),
+            null,
             ZignSecAuthenticationMarket.NORWAY,
             null
         )

--- a/member-service/src/test/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdServiceAuthenticateTest.kt
+++ b/member-service/src/test/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdServiceAuthenticateTest.kt
@@ -9,13 +9,11 @@ import com.hedvig.memberservice.query.MemberEntity
 import com.hedvig.memberservice.query.MemberRepository
 import com.hedvig.memberservice.query.SignedMemberRepository
 import com.hedvig.memberservice.services.redispublisher.RedisEventPublisher
-import com.hedvig.memberservice.web.dto.GenericBankIdAuthenticationRequest
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.axonframework.commandhandling.gateway.CommandGateway
 import org.junit.jupiter.api.Test
-import org.springframework.core.env.Environment
 import java.util.Optional
 import java.util.UUID
 

--- a/member-service/src/test/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdServiceAuthenticateTest.kt
+++ b/member-service/src/test/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdServiceAuthenticateTest.kt
@@ -178,7 +178,7 @@ class ZignSecBankIdServiceAuthenticateTest {
 
     companion object {
         private const val memberId = 1234L
-        private const val englishUrl = "https://www.dev.hedvigit.com/no-en/login?auth_token=token"
-        private const val norwegianUrl = "https://www.dev.hedvigit.com/no/login?auth_token=token"
+        private const val englishUrl = "https://www.dev.hedvigit.com/no-en/login#token=token"
+        private const val norwegianUrl = "https://www.dev.hedvigit.com/no/login#token=token"
     }
 }

--- a/zign-sec/src/main/java/com/hedvig/external/authentication/dto/ZignSecBankIdAuthenticationRequest.kt
+++ b/zign-sec/src/main/java/com/hedvig/external/authentication/dto/ZignSecBankIdAuthenticationRequest.kt
@@ -2,7 +2,7 @@ package com.hedvig.external.authentication.dto
 
 data class ZignSecBankIdAuthenticationRequest(
     val memberId: String,
-    val personalNumber: String? = null,
+    val personalNumber: String?,
     val language: String,
     val successUrl: String,
     val failUrl: String,


### PR DESCRIPTION
# Jira Issue: [HVG-862]

## What?
Attach the Authorization header as a URL parameter sent back when starting the static simple sign.

## Why?
The new static redirect we have needs to keep track of the token in order to be able to attach it later. Therefore we keep it around in a URL parameter.

## Optional checklist
- [ ] Unit tests written
- [ ] Tested locally
- [x] Codescouted


[HVG-862]: https://hedvig.atlassian.net/browse/HVG-862