### PR TITLE
read simple sign auth token from body instead of header

### DIFF
--- a/member-service/src/main/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdService.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdService.kt
@@ -46,11 +46,11 @@ class ZignSecBankIdService(
         personalNumber: String?,
         market: ZignSecAuthenticationMarket,
         acceptLanguage: String?,
-        authorization: String
+        token: String
     ): StartZignSecAuthenticationResult {
         if (market == ZignSecAuthenticationMarket.NORWAY && personalNumber == null) {
             return StartZignSecAuthenticationResult.StaticRedirect(
-                resolveNorwegianLoginUrl(memberId, acceptLanguage, authorization)
+                resolveNorwegianLoginUrl(memberId, acceptLanguage, token)
             )
         }
 
@@ -120,13 +120,13 @@ class ZignSecBankIdService(
     private fun resolveNorwegianLoginUrl(
         memberId: Long,
         acceptLanguage: String?,
-        authorization: String
+        token: String
     ): String {
         val path = when (resolveLocaleFromMember(memberId, acceptLanguage)?.language) {
             Locale("nb").language -> NORWEGIAN_BANK_ID_NORWEGIAN_LOGIN_PATH
             else -> NORWEGIAN_BANK_ID_ENGLISH_LOGIN_PATH
         }
-        return "$baseUrl$path#token=${URLEncoder.encode(authorization, Charsets.UTF_8)}"
+        return "$baseUrl$path#token=${URLEncoder.encode(token, Charsets.UTF_8)}"
     }
 
     private fun resolveTwoLetterLanguageFromMember(memberId: Long, acceptLanguage: String?) = when (resolveLocaleFromMember(memberId, acceptLanguage)?.language) {

--- a/member-service/src/main/java/com/hedvig/memberservice/web/AuthController.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/web/AuthController.kt
@@ -65,7 +65,6 @@ class AuthController @Autowired constructor(
     private fun auth(
         @RequestHeader("hedvig.token") memberId: Long,
         @RequestHeader(value = "Accept-Language", required = false) acceptLanguage: String?,
-        @RequestHeader("Authorization") authorization: String,
         @PathVariable("country") country: BankIdAuthCountry,
         @RequestBody request: GenericBankIdAuthenticationRequest
     ): ResponseEntity<ZignSecStartDto> {
@@ -79,7 +78,7 @@ class AuthController @Autowired constructor(
                 BankIdAuthCountry.denmark -> ZignSecAuthenticationMarket.DENMARK
             },
             acceptLanguage = acceptLanguage,
-            authorization = authorization.replace("Bearer ", "")
+            token = request.token
         )
 
         return when (result) {

--- a/member-service/src/main/java/com/hedvig/memberservice/web/dto/GenericBankIdAuthenticationRequest.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/web/dto/GenericBankIdAuthenticationRequest.kt
@@ -1,5 +1,6 @@
 package com.hedvig.memberservice.web.dto
 
 data class GenericBankIdAuthenticationRequest(
-    val personalNumber: String? = null
+    val personalNumber: String?,
+    val token: String
 )


### PR DESCRIPTION
# Jira Issue: []

## What?
Authorization header is implicitly stripped in api gateway. Read from body instead.

## Why?
Current code doesn't work 🙃 

## Optional checklist
- [ ] Unit tests written
- [ ] Tested locally
- [x] Codescouted
