### PR TITLE
add birthDate as part of the MemberDTO, since we have it

### DIFF
--- a/member-service/src/main/java/com/hedvig/memberservice/web/MembersController.java
+++ b/member-service/src/main/java/com/hedvig/memberservice/web/MembersController.java
@@ -110,6 +110,7 @@ public class MembersController {
       me.getSsn(),
       String.format("%s %s", me.getFirstName(), me.getLastName()), me.getFirstName(),
       me.getLastName(),
+      me.getBirthDate(),
       new ArrayList<>(),
       me.getBirthDate() == null ? null : me.getBirthDate().until(LocalDate.now()).getYears(),
       me.getEmail(),

--- a/member-service/src/main/java/com/hedvig/memberservice/web/dto/MemberMeDTO.java
+++ b/member-service/src/main/java/com/hedvig/memberservice/web/dto/MemberMeDTO.java
@@ -12,28 +12,28 @@ import java.util.UUID;
 @NoArgsConstructor(force = true)
 @AllArgsConstructor
 public class MemberMeDTO {
-  String memberId;
-  String ssn;
-  String name;
-  String firstName;
-  String lastName;
-  LocalDate birthDate;
-  List<String> familyMembers;
-  Integer age;
-  String email;
-  String address;
-  Integer livingAreaSqm;
-  String maskedBankAccountNumber;
-  String selectedCashback;
+    String memberId;
+    String ssn;
+    String name;
+    String firstName;
+    String lastName;
+    LocalDate birthDate;
+    List<String> familyMembers;
+    Integer age;
+    String email;
+    String address;
+    Integer livingAreaSqm;
+    String maskedBankAccountNumber;
+    String selectedCashback;
 
-  String paymentStatus;
-  LocalDate nextPaymentDate;
+    String paymentStatus;
+    LocalDate nextPaymentDate;
 
-  String selectedCashbackSignature;
-  String selectedCashbackParagraph;
-  String selectedCashbackImageUrl;
+    String selectedCashbackSignature;
+    String selectedCashbackParagraph;
+    String selectedCashbackImageUrl;
 
-  List<String> safetyIncreasers;
-  UUID trackingId;
-  String phoneNumber;
+    List<String> safetyIncreasers;
+    UUID trackingId;
+    String phoneNumber;
 }

--- a/member-service/src/main/java/com/hedvig/memberservice/web/dto/MemberMeDTO.java
+++ b/member-service/src/main/java/com/hedvig/memberservice/web/dto/MemberMeDTO.java
@@ -12,28 +12,28 @@ import java.util.UUID;
 @NoArgsConstructor(force = true)
 @AllArgsConstructor
 public class MemberMeDTO {
+  String memberId;
+  String ssn;
+  String name;
+  String firstName;
+  String lastName;
+  LocalDate birthDate;
+  List<String> familyMembers;
+  Integer age;
+  String email;
+  String address;
+  Integer livingAreaSqm;
+  String maskedBankAccountNumber;
+  String selectedCashback;
 
-  private String memberId;
-  private String ssn;
-  private String name;
-  private String firstName;
-  private String lastName;
-  private List<String> familyMembers;
-  private Integer age;
-  private String email;
-  private String address;
-  private Integer livingAreaSqm;
-  private String maskedBankAccountNumber;
-  private String selectedCashback;
+  String paymentStatus;
+  LocalDate nextPaymentDate;
 
-  private String paymentStatus;
-  private LocalDate nextPaymentDate;
+  String selectedCashbackSignature;
+  String selectedCashbackParagraph;
+  String selectedCashbackImageUrl;
 
-  private String selectedCashbackSignature;
-  private String selectedCashbackParagraph;
-  private String selectedCashbackImageUrl;
-
-  private List<String> safetyIncreasers;
-  private UUID trackingId;
-  private String phoneNumber;
+  List<String> safetyIncreasers;
+  UUID trackingId;
+  String phoneNumber;
 }


### PR DESCRIPTION
# Jira Issue: [HVG-859]

## What?
Add `birthDate` to the Member DTO we send down.

## Why?
It was needed in a feature inside Giraffe, and it was present. It also does not increase the amount of information we give out, as we already send the `ssn` value.

## Optional checklist
- [ ] Unit tests written
- [x] Tested locally
- [x] Codescouted


[HVG-859]: https://hedvig.atlassian.net/browse/HVG-859