### PR TITLE
remove some MDC entries that were added in debugging panic, and which are never cleared

### DIFF
--- a/member-service/src/main/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdService.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/services/signing/zignsec/ZignSecBankIdService.kt
@@ -15,7 +15,6 @@ import com.hedvig.memberservice.services.redispublisher.RedisEventPublisher
 import com.hedvig.memberservice.util.logger
 import com.hedvig.resolver.LocaleResolver
 import org.axonframework.commandhandling.gateway.CommandGateway
-import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -88,11 +87,9 @@ class ZignSecBankIdService(
     fun completeAuthentication(result: ZignSecAuthenticationResult) {
         when (result) {
             is ZignSecAuthenticationResult.Completed -> {
-                MDC.put("zignSecSign.memberId", result.memberId.toString())
 
                 signedMemberRepository.findBySsn(result.ssn).ifPresentOrElse(
                     { signedMember ->
-                        MDC.put("signedMember.memberId", signedMember.id.toString())
                         logger.info("ZignSec auth completion: Found existing signed member by SSN match")
 
                         if (result.memberId != signedMember.id) {

--- a/zign-sec/src/main/java/com/hedvig/external/zignSec/ZignSecSessionServiceImpl.kt
+++ b/zign-sec/src/main/java/com/hedvig/external/zignSec/ZignSecSessionServiceImpl.kt
@@ -18,7 +18,6 @@ import com.hedvig.external.zignSec.repository.entitys.ZignSecNotification
 import com.hedvig.external.zignSec.repository.entitys.ZignSecSession
 import com.hedvig.external.zignSec.repository.entitys.ZignSecAuthenticationEntity
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import org.springframework.stereotype.Service
 import java.text.DecimalFormat
 
@@ -157,8 +156,6 @@ class ZignSecSessionServiceImpl(
     override fun handleNotification(jsonRequest: String) {
         val request = objectMapper.readValue(jsonRequest, ZignSecNotificationRequest::class.java)
         val session = sessionRepository.findByReferenceId(request.id).get()
-        MDC.put("memberId", session.memberId.toString())
-        MDC.put("signSecSessionId", session.sessionId.toString())
 
         when (session.status) {
             ZignSecBankIdProgressStatus.INITIATED,


### PR DESCRIPTION
# Jira Issue: []

## What?
Remove some `MDC.put(...)` entries.

## Why?
They were never cleared, which makes them bleed out to other log statements happening on the same thread. This is bad, as it can falsely tag logs with the wrong member id.

## Optional checklist
- [ ] Unit tests written
- [ ] Tested locally
- [ ] Codescouted
