### PR TITLE
avoid firing a CreatePersonCommand if a person already exists (this is causing SQL failures)

### DIFF
--- a/member-service/src/main/java/com/hedvig/personservice/debts/DebtService.kt
+++ b/member-service/src/main/java/com/hedvig/personservice/debts/DebtService.kt
@@ -23,7 +23,6 @@ class DebtService @Autowired constructor(
             personService.createPerson(ssn)
         } finally {
             personService.checkDebt(ssn)
-            return
         }
     }
 

--- a/member-service/src/main/java/com/hedvig/personservice/persons/PersonService.kt
+++ b/member-service/src/main/java/com/hedvig/personservice/persons/PersonService.kt
@@ -28,6 +28,7 @@ class PersonService @Autowired constructor(
 ) {
 
     fun createPerson(ssn: String) {
+        if (personRepository.findBySsn(ssn) != null) return
         commandGateway.sendAndWait<Void>(CreatePersonCommand(ssn))
     }
 


### PR DESCRIPTION
# Jira Issue: []

## What?
- Check if a person already exists before creating one

## Why?
- [We're getting errors about it in the logs all the time, and those errors include the personal number](https://app.datadoghq.eu/logs?context_event=AQAAAXi24mr-xj4uRgAAAABBWGkyNG1zRUFBQTNKWTNUdTJMWjFnQUE&event=AQAAAXi24mr-xj4uRgAAAABBWGkyNG1zRUFBQTNKWTNUdTJMWjFnQUE&from_ts=1617975284849&index=%2A&live=false&messageDisplay=inline&query=host%3Ai-019f49da88b4f6f5c%20service%3Amember-service%20container_id%3A3be0c17308ab3113a398fcd5077ac2bb035c0c3badde1ad2bd9a688a09db278c&stream_sort=desc&to_event=AQAAAXi24o76xj4uzwAAAABBWGkyNG84d0FBQTNKWTNUdTJOV2ZRQUE&to_ts=1617976004346&viz=)
```
ERROR: duplicate key value violates unique constraint "uk8s1f994p4la2ipb13me2xqm1w"
  Detail: Key (aggregate_identifier, sequence_number)=(19801124XXXX, 0) already exists.
```

## Optional checklist
- [ ] Unit tests written
- [x] Tested locally
- [x] Codescouted
