### PR TITLE
ME-49: write actual event timestamp to model to get accurate created_at date

### DIFF
--- a/member-service/src/main/java/com/hedvig/auth/model/SimpleSignConnection.kt
+++ b/member-service/src/main/java/com/hedvig/auth/model/SimpleSignConnection.kt
@@ -1,6 +1,5 @@
 package com.hedvig.auth.model
 
-import org.hibernate.annotations.CreationTimestamp
 import java.time.Instant
 import javax.persistence.CascadeType
 import javax.persistence.Column
@@ -23,12 +22,9 @@ class SimpleSignConnection(
     @Column(name = "personal_number")
     val personalNumber: String,
     @Column(name = "country")
-    val country: String
+    val country: String,
+    val createdAt: Instant = Instant.now()
 ) {
     @Id @GeneratedValue
     val id: Long = 0
-
-    @field:CreationTimestamp
-    @Column(updatable = false)
-    lateinit var createdAt: Instant
 }

--- a/member-service/src/main/java/com/hedvig/auth/model/SwedishBankIdCredential.kt
+++ b/member-service/src/main/java/com/hedvig/auth/model/SwedishBankIdCredential.kt
@@ -1,11 +1,9 @@
 package com.hedvig.auth.model
 
-import org.hibernate.annotations.CreationTimestamp
 import java.time.Instant
 import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
-import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.persistence.JoinColumn
@@ -17,12 +15,9 @@ class SwedishBankIdCredential(
     @JoinColumn(unique = true)
     val user: User,
     @Column(unique = true)
-    val personalNumber: String
+    val personalNumber: String,
+    val createdAt: Instant = Instant.now()
 ) {
     @Id @GeneratedValue
     val id: Long = 0
-
-    @field:CreationTimestamp
-    @Column(updatable = false)
-    lateinit var createdAt: Instant
 }

--- a/member-service/src/main/java/com/hedvig/auth/model/User.kt
+++ b/member-service/src/main/java/com/hedvig/auth/model/User.kt
@@ -1,6 +1,5 @@
 package com.hedvig.auth.model
 
-import org.hibernate.annotations.CreationTimestamp
 import java.time.Instant
 import java.util.UUID
 import javax.persistence.CascadeType
@@ -14,14 +13,11 @@ import javax.persistence.Table
 @Table(name = "user_entity")
 class User(
     @Column(unique = true)
-    val associatedMemberId: String
+    val associatedMemberId: String,
+    val createdAt: Instant = Instant.now()
 ) {
     @Id
     val id: UUID = UUID.randomUUID()
-
-    @field:CreationTimestamp
-    @Column(updatable = false)
-    lateinit var createdAt: Instant
 
     @OneToOne(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
     var swedishBankIdCredential: SwedishBankIdCredential? = null

--- a/member-service/src/main/java/com/hedvig/auth/model/ZignSecCredential.kt
+++ b/member-service/src/main/java/com/hedvig/auth/model/ZignSecCredential.kt
@@ -10,7 +10,6 @@ import javax.persistence.JoinColumn
 import javax.persistence.OneToOne
 import javax.persistence.Table
 import javax.persistence.UniqueConstraint
-import org.hibernate.annotations.CreationTimestamp
 
 @Entity
 @Table(
@@ -23,13 +22,10 @@ class ZignSecCredential(
     @Column(name = "id_provider_name")
     val idProviderName: String,
     @Column(name = "id_provider_person_id")
-    val idProviderPersonId: String
+    val idProviderPersonId: String,
+    val createdAt: Instant = Instant.now()
 ) {
     @Id
     @GeneratedValue
     val id: Long = 0
-
-    @field:CreationTimestamp
-    @Column(updatable = false)
-    lateinit var createdAt: Instant
 }

--- a/member-service/src/test/java/com/hedvig/auth/import/ZignSecMemberImporterTest.kt
+++ b/member-service/src/test/java/com/hedvig/auth/import/ZignSecMemberImporterTest.kt
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.hedvig.auth.model.UserRepository
 import com.hedvig.auth.model.ZignSecCredentialRepository
 import com.hedvig.memberservice.events.DanishMemberSignedEvent
+import com.hedvig.memberservice.events.MemberSignedEvent
 import com.hedvig.memberservice.events.NorwegianMemberSignedEvent
+import java.time.Instant
 import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -25,7 +27,7 @@ internal class ZignSecMemberImporterTest @Autowired constructor(
     )
 
     @Test
-    fun `Norwegian - signed member is exported on event`() {
+    fun `Norwegian - signed member is imported on event`() {
         val memberId = 123L
         val personalNumber = "01129955131"
         val idProviderName = "test-provider"
@@ -33,7 +35,8 @@ internal class ZignSecMemberImporterTest @Autowired constructor(
         val providerJson = zignSecNotificationJson(idProviderName, idProviderPersonId)
 
         importer.on(
-            NorwegianMemberSignedEvent(memberId, personalNumber, providerJson, null)
+            NorwegianMemberSignedEvent(memberId, personalNumber, providerJson, null),
+            Instant.now()
         )
 
         val user = userRepository.findByAssociatedMemberId(memberId.toString())
@@ -43,7 +46,26 @@ internal class ZignSecMemberImporterTest @Autowired constructor(
     }
 
     @Test
-    fun `Norwegian - exporting the same user twice simply ignored second attempt`() {
+    fun `Norwegian - imported member receives correct timestamp`() {
+        val memberId = 123L
+        val personalNumber = "201212121212"
+        val idProviderName = "test-provider"
+        val idProviderPersonId = "person-id"
+        val providerJson = zignSecNotificationJson(idProviderName, idProviderPersonId)
+        val time = Instant.now().minusSeconds(1000)
+
+        importer.on(
+            NorwegianMemberSignedEvent(memberId, personalNumber, providerJson, null),
+            time
+        )
+
+        val user = userRepository.findByAssociatedMemberId(memberId.toString())
+        assertThat(user?.createdAt).isEqualTo(time)
+        assertThat(user?.zignSecCredential?.createdAt).isEqualTo(time)
+    }
+
+    @Test
+    fun `Norwegian - importing the same user twice simply ignored second attempt`() {
         val memberId = 123L
         val personalNumber = "01129955131"
         val idProviderName = "test-provider"
@@ -51,10 +73,12 @@ internal class ZignSecMemberImporterTest @Autowired constructor(
         val providerJson = zignSecNotificationJson(idProviderName, idProviderPersonId)
 
         importer.on(
-            NorwegianMemberSignedEvent(memberId, personalNumber, providerJson, null)
+            NorwegianMemberSignedEvent(memberId, personalNumber, providerJson, null),
+            Instant.now()
         )
         importer.on(
-            NorwegianMemberSignedEvent(memberId, personalNumber, providerJson, null)
+            NorwegianMemberSignedEvent(memberId, personalNumber, providerJson, null),
+            Instant.now()
         )
 
         val users = userRepository.findAll()
@@ -71,10 +95,12 @@ internal class ZignSecMemberImporterTest @Autowired constructor(
         val providerJson = zignSecNotificationJson(idProviderName, idProviderPersonId)
 
         importer.on(
-            NorwegianMemberSignedEvent(memberId1, personalNumber, providerJson, null)
+            NorwegianMemberSignedEvent(memberId1, personalNumber, providerJson, null),
+            Instant.now()
         )
         importer.on(
-            NorwegianMemberSignedEvent(memberId2, personalNumber, providerJson, null)
+            NorwegianMemberSignedEvent(memberId2, personalNumber, providerJson, null),
+            Instant.now()
         )
 
         val users = userRepository.findAll()
@@ -84,7 +110,7 @@ internal class ZignSecMemberImporterTest @Autowired constructor(
     }
 
     @Test
-    fun `Danish - signed member is exported on event`() {
+    fun `Danish - signed member is imported on event`() {
         val memberId = 123L
         val personalNumber = "220550-6218"
         val idProviderName = "test-provider"
@@ -92,7 +118,8 @@ internal class ZignSecMemberImporterTest @Autowired constructor(
         val providerJson = zignSecNotificationJson(idProviderName, idProviderPersonId)
 
         importer.on(
-            DanishMemberSignedEvent(memberId, personalNumber, providerJson, null)
+            DanishMemberSignedEvent(memberId, personalNumber, providerJson, null),
+            Instant.now()
         )
 
         val user = userRepository.findByAssociatedMemberId(memberId.toString())
@@ -102,7 +129,26 @@ internal class ZignSecMemberImporterTest @Autowired constructor(
     }
 
     @Test
-    fun `Danish - exporting the same user twice simply ignored second attempt`() {
+    fun `Danish - imported member receives correct timestamp`() {
+        val memberId = 123L
+        val personalNumber = "201212121212"
+        val idProviderName = "test-provider"
+        val idProviderPersonId = "person-id"
+        val providerJson = zignSecNotificationJson(idProviderName, idProviderPersonId)
+        val time = Instant.now().minusSeconds(1000)
+
+        importer.on(
+            DanishMemberSignedEvent(memberId, personalNumber, providerJson, null),
+            time
+        )
+
+        val user = userRepository.findByAssociatedMemberId(memberId.toString())
+        assertThat(user?.createdAt).isEqualTo(time)
+        assertThat(user?.zignSecCredential?.createdAt).isEqualTo(time)
+    }
+
+    @Test
+    fun `Danish - importing the same user twice simply ignored second attempt`() {
         val memberId = 123L
         val personalNumber = "220550-6218"
         val idProviderName = "test-provider"
@@ -110,10 +156,12 @@ internal class ZignSecMemberImporterTest @Autowired constructor(
         val providerJson = zignSecNotificationJson(idProviderName, idProviderPersonId)
 
         importer.on(
-            DanishMemberSignedEvent(memberId, personalNumber, providerJson, null)
+            DanishMemberSignedEvent(memberId, personalNumber, providerJson, null),
+            Instant.now()
         )
         importer.on(
-            DanishMemberSignedEvent(memberId, personalNumber, providerJson, null)
+            DanishMemberSignedEvent(memberId, personalNumber, providerJson, null),
+            Instant.now()
         )
 
         val users = userRepository.findAll()
@@ -130,10 +178,12 @@ internal class ZignSecMemberImporterTest @Autowired constructor(
         val providerJson = zignSecNotificationJson(idProviderName, idProviderPersonId)
 
         importer.on(
-            DanishMemberSignedEvent(memberId1, personalNumber, providerJson, null)
+            DanishMemberSignedEvent(memberId1, personalNumber, providerJson, null),
+            Instant.now()
         )
         importer.on(
-            DanishMemberSignedEvent(memberId2, personalNumber, providerJson, null)
+            DanishMemberSignedEvent(memberId2, personalNumber, providerJson, null),
+            Instant.now()
         )
 
         val users = userRepository.findAll()


### PR DESCRIPTION
# Jira Issue: [ME-49]

## What?
- Make `created_at` timestamps of the auth model injectable rather than auto-generated timestamps, and send in the actual timestamp value of the originating Axon events.

## Why?
- We wish to have the created_at timestamp of these models to align with when the people behind them actually entered the information.

## Optional checklist
- [x] Unit tests written
- [x] Tested locally
- [x] Codescouted


[ME-49]: https://hedvig.atlassian.net/browse/ME-49