### PR TITLE
MX-84: Populate user-connected member with basic data upon login

### DIFF
--- a/member-service/src/main/java/com/hedvig/memberservice/aggregates/MemberAggregate.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/aggregates/MemberAggregate.kt
@@ -12,6 +12,7 @@ import com.hedvig.memberservice.commands.InactivateMemberCommand
 import com.hedvig.memberservice.commands.InitializeAppleUserCommand
 import com.hedvig.memberservice.commands.MemberSimpleSignedCommand
 import com.hedvig.memberservice.commands.MemberUpdateContactInformationCommand
+import com.hedvig.memberservice.commands.PopulateMemberThroughLoginDataCommand
 import com.hedvig.memberservice.commands.SelectNewCashbackCommand
 import com.hedvig.memberservice.commands.SetFraudulentStatusCommand
 import com.hedvig.memberservice.commands.SignMemberFromUnderwriterCommand
@@ -255,6 +256,11 @@ class MemberAggregate() {
             && member.birthDate != cmd.birthDate) {
             apply(BirthDateUpdatedEvent(id, cmd.birthDate))
         }
+    }
+
+    @CommandHandler
+    fun handle(cmd: PopulateMemberThroughLoginDataCommand) {
+        maybeApplyNameUpdatedEvent(cmd.givenName, cmd.surname)
     }
 
     @CommandHandler

--- a/member-service/src/main/java/com/hedvig/memberservice/commands/PopulateMemberThroughLoginDataCommand.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/commands/PopulateMemberThroughLoginDataCommand.kt
@@ -1,0 +1,9 @@
+package com.hedvig.memberservice.commands
+
+import org.axonframework.commandhandling.TargetAggregateIdentifier
+
+data class PopulateMemberThroughLoginDataCommand(
+    @TargetAggregateIdentifier var id: Long,
+    val givenName: String,
+    val surname: String
+)

--- a/member-service/src/main/java/com/hedvig/memberservice/commands/PopulateMemberThroughLoginDataCommand.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/commands/PopulateMemberThroughLoginDataCommand.kt
@@ -4,6 +4,6 @@ import org.axonframework.commandhandling.TargetAggregateIdentifier
 
 data class PopulateMemberThroughLoginDataCommand(
     @TargetAggregateIdentifier var id: Long,
-    val givenName: String,
-    val surname: String
+    val givenName: String?,
+    val surname: String?
 )

--- a/member-service/src/main/java/com/hedvig/memberservice/events/NameUpdatedEvent.kt
+++ b/member-service/src/main/java/com/hedvig/memberservice/events/NameUpdatedEvent.kt
@@ -1,6 +1,6 @@
 package com.hedvig.memberservice.events
 
-class NameUpdatedEvent(
+data class NameUpdatedEvent(
     override val memberId: Long,
     val firstName: String?,
     val lastName: String?

--- a/member-service/src/test/java/com/hedvig/memberservice/MemberAggregateTests.kt
+++ b/member-service/src/test/java/com/hedvig/memberservice/MemberAggregateTests.kt
@@ -516,7 +516,7 @@ class MemberAggregateTests {
     }
 
     @Test
-    fun `empty member - information is not populated through login command if the data is the same`() {
+    fun `already named member - information is not updated populated through login command`() {
         val memberId = 1234L
         fixture
             .given(
@@ -527,6 +527,22 @@ class MemberAggregateTests {
                 PopulateMemberThroughLoginDataCommand(memberId, "First", "Lastname")
             )
             .expectNoEvents()
+    }
+
+    @Test
+    fun `already named member - information is updated if one name changes`() {
+        val memberId = 1234L
+        fixture
+            .given(
+                MemberCreatedEvent(memberId, MemberStatus.INITIATED, Instant.now()),
+                NameUpdatedEvent(memberId, "First", "Lastname")
+            )
+            .`when`(
+                PopulateMemberThroughLoginDataCommand(memberId, "NewFirst", null)
+            )
+            .expectEvents(
+                NameUpdatedEvent(memberId, "NewFirst", "Lastname")
+            )
     }
 
     private inner class AggregateFactoryM<T> constructor(aggregateType: Class<T>?) : AbstractAggregateFactory<T>(aggregateType) {


### PR DESCRIPTION
# Jira Issue: [MX-84]

## What?
- When a user logs in, populate its member with some data given to us by the login provider
- Only first and last name for now
- No new Member-level events are triggered if the names are already equal to the existing ones we know
- Rewrite some JUnit4+Mockito to JUnit5+MockK

## Why?
- When members are created and linked to a user through the new non-signed-member login, we wish to populate its associated member with some basic data.
- We bet that adding first and last name will be enough for now.

## Optional checklist
- [x] Unit tests written
- [ ] Tested locally
- [x] Codescouted
